### PR TITLE
feat: Add config to settings GraphQL query

### DIFF
--- a/client/src/generated/graphql_schema.tsx
+++ b/client/src/generated/graphql_schema.tsx
@@ -86,9 +86,13 @@ export type QueryPublishedOperationByHashArgs = {
 export type Settings = {
   __typename?: 'Settings';
   tzStatsUrl: Scalars['String'];
-  minterContractAddress?: Maybe<Scalars['String']>;
-  nftContractAddress?: Maybe<Scalars['String']>;
-  adminAddress?: Maybe<Scalars['String']>;
+  rpc: Scalars['String'];
+  contracts: SettingsContracts;
+};
+
+export type SettingsContracts = {
+  __typename?: 'SettingsContracts';
+  nft: Scalars['String'];
 };
 
 export type Subscription = {

--- a/server/src/components/context.ts
+++ b/server/src/components/context.ts
@@ -24,6 +24,7 @@ export interface Context {
   tzStatsApiUrl: string;
   tzStatsUrl: string;
   tzClient: TezosToolkit;
+  configStore: Configstore;
 }
 
 export interface SessionContext extends Context {
@@ -71,6 +72,7 @@ export default async function createContext(): Promise<Context> {
     tzStatsApiUrl,
     tzStatsUrl,
     tzRpcUrl,
-    tzClient
+    tzClient,
+    configStore
   };
 }

--- a/server/src/generated/graphql_schema.ts
+++ b/server/src/generated/graphql_schema.ts
@@ -95,9 +95,13 @@ export type QueryPublishedOperationByHashArgs = {
 export type Settings = {
   __typename?: 'Settings';
   tzStatsUrl: Scalars['String'];
-  minterContractAddress?: Maybe<Scalars['String']>;
-  nftContractAddress?: Maybe<Scalars['String']>;
-  adminAddress?: Maybe<Scalars['String']>;
+  rpc: Scalars['String'];
+  contracts: SettingsContracts;
+};
+
+export type SettingsContracts = {
+  __typename?: 'SettingsContracts';
+  nft: Scalars['String'];
 };
 
 export type Subscription = {
@@ -232,6 +236,7 @@ export type ResolversTypes = ResolversObject<{
   PublishedOperation: ResolverTypeWrapper<PublishedOperation>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
   Settings: ResolverTypeWrapper<Settings>;
+  SettingsContracts: ResolverTypeWrapper<SettingsContracts>;
   Mutation: ResolverTypeWrapper<{}>;
   Subscription: ResolverTypeWrapper<{}>;
 }>;
@@ -246,6 +251,7 @@ export type ResolversParentTypes = ResolversObject<{
   PublishedOperation: PublishedOperation;
   Boolean: Scalars['Boolean'];
   Settings: Settings;
+  SettingsContracts: SettingsContracts;
   Mutation: {};
   Subscription: {};
 }>;
@@ -348,21 +354,20 @@ export type SettingsResolvers<
   ParentType extends ResolversParentTypes['Settings'] = ResolversParentTypes['Settings']
 > = ResolversObject<{
   tzStatsUrl?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  minterContractAddress?: Resolver<
-    Maybe<ResolversTypes['String']>,
+  rpc?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  contracts?: Resolver<
+    ResolversTypes['SettingsContracts'],
     ParentType,
     ContextType
   >;
-  nftContractAddress?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
-  adminAddress?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+}>;
+
+export type SettingsContractsResolvers<
+  ContextType = Context,
+  ParentType extends ResolversParentTypes['SettingsContracts'] = ResolversParentTypes['SettingsContracts']
+> = ResolversObject<{
+  nft?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 }>;
 
@@ -391,6 +396,7 @@ export type Resolvers<ContextType = Context> = ResolversObject<{
   PublishedOperation?: PublishedOperationResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
   Settings?: SettingsResolvers<ContextType>;
+  SettingsContracts?: SettingsContractsResolvers<ContextType>;
   Subscription?: SubscriptionResolvers<ContextType>;
 }>;
 

--- a/server/src/resolvers/queries/index.ts
+++ b/server/src/resolvers/queries/index.ts
@@ -72,8 +72,13 @@ const Query: QueryResolvers = {
     }));
   },
 
-  settings(_parent, _args, { tzStatsUrl }) {
-    return { tzStatsUrl };
+  settings(_parent, _args, { tzStatsUrl, configStore }) {
+    const config = configStore.all;
+    return {
+      tzStatsUrl: tzStatsUrl,
+      rpc: config.rpc,
+      contracts: config.contracts
+    };
   }
 };
 

--- a/server/src/schema.graphql
+++ b/server/src/schema.graphql
@@ -21,11 +21,14 @@ type PublishedOperation {
   retry: Boolean!
 }
 
+type SettingsContracts {
+  nft: String!
+}
+
 type Settings {
   tzStatsUrl: String!
-  minterContractAddress: String
-  nftContractAddress: String
-  adminAddress: String
+  rpc: String!
+  contracts: SettingsContracts!
 }
 
 ## Toplevel Types


### PR DESCRIPTION
This PR adds config fields to the settings query. To query all fields in this query:

```
{
  settings {
    tzStatsUrl
    rpc
    contracts {
      nft
    }
  }
}
```