### PR TITLE
changed min_bid logic to include min_raise and min_percent_raise

### DIFF
--- a/contracts/bin/english_auction_tez.tz
+++ b/contracts/bin/english_auction_tez.tz
@@ -3,11 +3,12 @@
         (or (pair %configure
                (mutez %opening_price)
                (pair (nat %min_raise_percent)
-                     (pair (nat %round_time)
-                           (pair (nat %extend_time)
-                                 (pair (list %asset
-                                          (pair (address %fa2_address) (list %fa2_batch (pair (nat %token_id) (nat %amount)))))
-                                       (pair (timestamp %start_time) (timestamp %end_time)))))))
+                     (pair (mutez %min_raise)
+                           (pair (nat %round_time)
+                                 (pair (nat %extend_time)
+                                       (pair (list %asset
+                                                (pair (address %fa2_address) (list %fa2_batch (pair (nat %token_id) (nat %amount)))))
+                                             (pair (timestamp %start_time) (timestamp %end_time))))))))
             (nat %resolve))) ;
   storage
     (pair (address %admin)
@@ -23,7 +24,8 @@
                                                        (pair (int %extend_time)
                                                              (pair (list %asset
                                                                       (pair (address %fa2_address) (list %fa2_batch (pair (nat %token_id) (nat %amount)))))
-                                                                   (pair (nat %min_raise_percent) (pair (timestamp %end_time) (address %highest_bidder)))))))))))))) ;
+                                                                   (pair (nat %min_raise_percent)
+                                                                         (pair (mutez %min_raise) (pair (timestamp %end_time) (address %highest_bidder))))))))))))))) ;
   code { LAMBDA
            (pair bool string)
            unit
@@ -84,13 +86,15 @@
                                                         (pair timestamp
                                                               (pair int
                                                                     (pair int
-                                                                          (pair (list (pair address (list (pair nat nat)))) (pair nat (pair timestamp address))))))))))))))
+                                                                          (pair (list (pair address (list (pair nat nat))))
+                                                                                (pair nat (pair mutez (pair timestamp address)))))))))))))))
            (pair mutez
                  (pair timestamp
                        (pair timestamp
                              (pair int
                                    (pair int
-                                         (pair (list (pair address (list (pair nat nat)))) (pair nat (pair timestamp address))))))))
+                                         (pair (list (pair address (list (pair nat nat))))
+                                               (pair nat (pair mutez (pair timestamp address)))))))))
            { DUP ;
              CDR ;
              CDR ;
@@ -114,7 +118,8 @@
                        (pair timestamp
                              (pair int
                                    (pair int
-                                         (pair (list (pair address (list (pair nat nat)))) (pair nat (pair timestamp address))))))))
+                                         (pair (list (pair address (list (pair nat nat))))
+                                               (pair nat (pair mutez (pair timestamp address)))))))))
            bool
            { DUP ;
              CDR ;
@@ -132,6 +137,7 @@
              COMPARE ;
              GT ;
              SWAP ;
+             CDR ;
              CDR ;
              CDR ;
              CDR ;
@@ -224,6 +230,7 @@
                  CDR ;
                  CDR ;
                  CDR ;
+                 CDR ;
                  COMPARE ;
                  EQ ;
                  SWAP ;
@@ -234,14 +241,33 @@
                  COMPARE ;
                  GE ;
                  AND ;
-                 PUSH nat 100 ;
+                 SWAP ;
+                 DUP ;
+                 DUG 2 ;
+                 CDR ;
+                 CDR ;
+                 CDR ;
+                 CDR ;
+                 CDR ;
+                 CDR ;
+                 CDR ;
+                 CAR ;
                  DIG 2 ;
                  DUP ;
                  DUG 3 ;
                  CAR ;
+                 ADD ;
+                 AMOUNT ;
+                 COMPARE ;
+                 GE ;
+                 PUSH nat 100 ;
                  DIG 3 ;
                  DUP ;
                  DUG 4 ;
+                 CAR ;
+                 DIG 4 ;
+                 DUP ;
+                 DUG 5 ;
                  CDR ;
                  CDR ;
                  CDR ;
@@ -253,12 +279,13 @@
                  EDIV ;
                  IF_NONE { PUSH string "DIV by 0" ; FAILWITH } {} ;
                  CAR ;
-                 DIG 2 ;
+                 DIG 3 ;
                  CAR ;
                  ADD ;
                  AMOUNT ;
                  COMPARE ;
                  GE ;
+                 OR ;
                  OR ;
                  PAIR ;
                  DIG 5 ;
@@ -281,6 +308,7 @@
                  EXEC ;
                  DROP ;
                  DUP ;
+                 CDR ;
                  CDR ;
                  CDR ;
                  CDR ;
@@ -317,17 +345,31 @@
                  CDR ;
                  CDR ;
                  CDR ;
+                 CDR ;
                  CAR ;
                  SUB ;
                  COMPARE ;
                  LE ;
                  IF { SWAP ; DUP ; DUG 2 ; CDR ; CDR ; CDR ; CDR ; CAR ; NOW ; ADD }
-                    { SWAP ; DUP ; DUG 2 ; CDR ; CDR ; CDR ; CDR ; CDR ; CDR ; CDR ; CAR } ;
+                    { SWAP ; DUP ; DUG 2 ; CDR ; CDR ; CDR ; CDR ; CDR ; CDR ; CDR ; CDR ; CAR } ;
                  DIG 2 ;
                  CDR ;
                  AMOUNT ;
                  PAIR ;
                  SENDER ;
+                 SWAP ;
+                 DUP ;
+                 DUG 2 ;
+                 CDR ;
+                 CDR ;
+                 CDR ;
+                 CDR ;
+                 CDR ;
+                 CDR ;
+                 CDR ;
+                 CDR ;
+                 CAR ;
+                 PAIR ;
                  SWAP ;
                  DUP ;
                  DUG 2 ;
@@ -418,7 +460,20 @@
                  CDR ;
                  CDR ;
                  CDR ;
+                 CDR ;
                  DIG 2 ;
+                 PAIR ;
+                 SWAP ;
+                 DUP ;
+                 DUG 2 ;
+                 CDR ;
+                 CDR ;
+                 CDR ;
+                 CDR ;
+                 CDR ;
+                 CDR ;
+                 CDR ;
+                 CAR ;
                  PAIR ;
                  SWAP ;
                  DUP ;
@@ -594,6 +649,7 @@
                  CDR ;
                  CDR ;
                  CDR ;
+                 CDR ;
                  DIG 5 ;
                  SWAP ;
                  EXEC ;
@@ -614,7 +670,8 @@
                                   (pair timestamp
                                         (pair int
                                               (pair int
-                                                    (pair (list (pair address (list (pair nat nat)))) (pair nat (pair timestamp address)))))))) ;
+                                                    (pair (list (pair address (list (pair nat nat))))
+                                                          (pair nat (pair mutez (pair timestamp address))))))))) ;
                  SWAP ;
                  UPDATE ;
                  DIG 3 ;
@@ -675,10 +732,12 @@
                  CDR ;
                  CDR ;
                  CDR ;
+                 CDR ;
                  CAR ;
                  DIG 2 ;
                  DUP ;
                  DUG 3 ;
+                 CDR ;
                  CDR ;
                  CDR ;
                  CDR ;
@@ -709,10 +768,12 @@
                  CDR ;
                  CDR ;
                  CDR ;
+                 CDR ;
                  CAR ;
                  DIG 3 ;
                  DUP ;
                  DUG 4 ;
+                 CDR ;
                  CDR ;
                  CDR ;
                  CDR ;
@@ -735,6 +796,7 @@
                  DIG 2 ;
                  DUP ;
                  DUG 3 ;
+                 CDR ;
                  CDR ;
                  CDR ;
                  CDR ;
@@ -763,6 +825,7 @@
                  DIG 3 ;
                  DUP ;
                  DUG 4 ;
+                 CDR ;
                  CDR ;
                  CDR ;
                  CDR ;
@@ -817,6 +880,7 @@
                  DUG 3 ;
                  CDR ;
                  CDR ;
+                 CDR ;
                  CAR ;
                  COMPARE ;
                  GT ;
@@ -835,6 +899,14 @@
                  CDR ;
                  CDR ;
                  CDR ;
+                 CDR ;
+                 PAIR ;
+                 SWAP ;
+                 DUP ;
+                 DUG 2 ;
+                 CDR ;
+                 CDR ;
+                 CAR ;
                  PAIR ;
                  SWAP ;
                  DUP ;
@@ -849,7 +921,18 @@
                  CDR ;
                  CDR ;
                  CDR ;
+                 CDR ;
                  CAR ;
+                 PAIR ;
+                 SWAP ;
+                 DUP ;
+                 DUG 2 ;
+                 CDR ;
+                 CDR ;
+                 CDR ;
+                 CDR ;
+                 CAR ;
+                 INT ;
                  PAIR ;
                  SWAP ;
                  DUP ;
@@ -865,13 +948,6 @@
                  DUG 2 ;
                  CDR ;
                  CDR ;
-                 CAR ;
-                 INT ;
-                 PAIR ;
-                 SWAP ;
-                 DUP ;
-                 DUG 2 ;
-                 CDR ;
                  CDR ;
                  CDR ;
                  CDR ;
@@ -881,6 +957,7 @@
                  SWAP ;
                  DUP ;
                  DUG 2 ;
+                 CDR ;
                  CDR ;
                  CDR ;
                  CDR ;
@@ -897,6 +974,7 @@
                  ADDRESS ;
                  SENDER ;
                  DIG 3 ;
+                 CDR ;
                  CDR ;
                  CDR ;
                  CDR ;
@@ -1005,6 +1083,7 @@
                  CDR ;
                  CDR ;
                  CDR ;
+                 CDR ;
                  SELF ;
                  ADDRESS ;
                  DIG 2 ;
@@ -1045,7 +1124,8 @@
                                   (pair timestamp
                                         (pair int
                                               (pair int
-                                                    (pair (list (pair address (list (pair nat nat)))) (pair nat (pair timestamp address)))))))) ;
+                                                    (pair (list (pair address (list (pair nat nat))))
+                                                          (pair nat (pair mutez (pair timestamp address))))))))) ;
                  SWAP ;
                  UPDATE ;
                  DIG 3 ;

--- a/contracts/ligo/src/english_auction_tez.mligo
+++ b/contracts/ligo/src/english_auction_tez.mligo
@@ -23,6 +23,7 @@ type auction =
     extend_time : int;
     asset : (tokens list);
     min_raise_percent : nat;
+    min_raise : tez;
     end_time : timestamp;
     highest_bidder : address;
   }
@@ -32,6 +33,7 @@ type configure_param =
   {
     opening_price : tez;
     min_raise_percent : nat;
+    min_raise : tez;
     round_time : nat;
     extend_time : nat;
     asset : (tokens list);
@@ -113,6 +115,7 @@ let first_bid (auction, storage : auction * storage) : bool =
 
 let valid_bid_amount (auction, storage : auction * storage) : bool =
   (Tezos.amount >= (auction.current_bid + ((auction.min_raise_percent *  auction.current_bid)/ 100n))) ||
+  (Tezos.amount >= auction.current_bid + auction.min_raise)                                            ||
   ((Tezos.amount >= auction.current_bid) && first_bid(auction, storage))
 
 let configure_auction(configure_param, storage : configure_param * storage) : return = begin
@@ -135,6 +138,7 @@ let configure_auction(configure_param, storage : configure_param * storage) : re
       extend_time = int(configure_param.extend_time);
       asset = configure_param.asset;
       min_raise_percent = configure_param.min_raise_percent;
+      min_raise = configure_param.min_raise;
       end_time = configure_param.end_time;
       highest_bidder = Tezos.sender;
       last_bid_time = configure_param.start_time; 


### PR DESCRIPTION
We want to determine if a new bid amount is valid by checking it is greater than or equal to EITHER the last bid raised by `min_raise` or the last bid raised by `min_raise_percent` of it. If we just go with `min_raise_percent` it could discourage bidding wars at higher prices and if we just go with `min_raise` it may be difficult to choose a value that adequately prevents sniping at higher prices while also not discouraging bidding at lower prices. 