### PR TITLE
Added placeholder Pinata API keys.

### DIFF
--- a/config/minter.mainnet.example.json
+++ b/config/minter.mainnet.example.json
@@ -1,6 +1,6 @@
 {
 	"rpc": "https://mainnet-tezos.giganode.io",
-  "network": "mainnet",
+        "network": "mainnet",
 	"bcd": {
 		"api": "https://api.better-call.dev",
 		"gui": "https://better-call.dev"
@@ -8,6 +8,10 @@
 	"admin": {
 		"address": "<YOUR_TZ_PUBLIC_ADDRESS_HERE>",
 		"secret": "<YOUR_TZ_PRIVATE_KEY_HERE>"
+	},
+	"pinata": {
+		"apiKey": "<YOUR_PINATA_API_KEY_HERE>",
+		"apiSecret": "<YOUR_PINATA_API_SECRET_HERE>"
 	},
 	"contracts": {}
 }


### PR DESCRIPTION
README says:

> The example testnet and mainnet configurations in the config/ folder have placeholder Pinata API keys...

But mainnet config was missing it. This PR fixes that.