### PR TITLE
Reset Wallet Selection on Permission Failure

### DIFF
--- a/client/src/lib/system.ts
+++ b/client/src/lib/system.ts
@@ -170,15 +170,21 @@ async function initWallet(
 
   if (!activeAccount) {
     if (forceConnect) {
-      await wallet.requestPermissions({
-        network: {
-          type:
-            system.config.network === 'edo2net'
-              ? (system.config.network as NetworkType)
-              : network,
-          rpcUrl: system.config.rpc
-        }
-      });
+      try {
+        await wallet.requestPermissions({
+          network: {
+            type:
+              system.config.network === 'edo2net'
+                ? (system.config.network as NetworkType)
+                : network,
+            rpcUrl: system.config.rpc
+          }
+        });
+      } catch (error) {
+        // requestPermissions failed - reset wallet selection
+        wallet.clearActiveAccount();
+        throw error;
+      }
     } else {
       return false;
     }
@@ -222,7 +228,9 @@ export async function connectWallet(
   system: SystemWithToolkit,
   eventHandlers?: DAppClientOptions['eventHandlers']
 ): Promise<SystemWithWallet> {
+  console.log('connectWallet - initWallet');
   await initWallet(system, true, eventHandlers);
+  console.log('connectWallet - createSystemWithWallet');
   return await createSystemWithWallet(system);
 }
 

--- a/client/src/lib/system.ts
+++ b/client/src/lib/system.ts
@@ -228,9 +228,7 @@ export async function connectWallet(
   system: SystemWithToolkit,
   eventHandlers?: DAppClientOptions['eventHandlers']
 ): Promise<SystemWithWallet> {
-  console.log('connectWallet - initWallet');
   await initWallet(system, true, eventHandlers);
-  console.log('connectWallet - createSystemWithWallet');
   return await createSystemWithWallet(system);
 }
 


### PR DESCRIPTION
When connecting to a wallet, if the permission request fails, it can get stuck in a state where the user cannot change to a different wallet type.

This fix will allow the wallet selection to reappear after a permission failure.

# To replicate original bug:

- Try to connect Kukai to sandbox
- The permission request will fail and a warning will appear
- However, if hitting connect again, it always assumes the same Kukai network and shows the error again.

# After fix:

- The warning will appear first time
- When hitting connect again, it allows selecting a different wallet