### PR TITLE
Fix transferring token error

### DIFF
--- a/client/src/components/common/TransferToken.tsx
+++ b/client/src/components/common/TransferToken.tsx
@@ -1,4 +1,4 @@
-import React, { useState, MutableRefObject } from 'react';
+import React, { useState, MutableRefObject, useEffect } from 'react';
 import {
   Box,
   Flex,
@@ -65,7 +65,7 @@ interface TransferTokenButtonProps {
 }
 
 export function TransferTokenButton(props: TransferTokenButtonProps) {
-  const { status } = useSelector(s => s.status.transferToken);
+  const { status, error } = useSelector(s => s.status.transferToken);
   const dispatch = useDispatch();
 
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -87,6 +87,11 @@ export function TransferTokenButton(props: TransferTokenButtonProps) {
       onClose();
     }
   };
+
+  useEffect(() => {
+    // Close the modal (standard error modal is shown)
+    onClose();
+  }, [error]);
 
   return (
     <>


### PR DESCRIPTION
I wasn't sure what the standard pattern is for handling errors, but this seems to work well in this case.

# To Reproduce Bug

- Try to transfer a token
- Choose in invalid destination address "alice"
- Error modal will show below, but the "Transferring Token..." does not close (and now blocks the UI)
- The user is forced to refresh the page

![image](https://user-images.githubusercontent.com/703880/110222731-08a49800-7e9a-11eb-9f79-1ae477ee3682.png)


# After FIX

- The "Transferring Token..." modal closes immediately upon error
- The error modal is shown below
- The user can try again

![image](https://user-images.githubusercontent.com/703880/110222752-1fe38580-7e9a-11eb-8e80-d136279fc56a.png)
