### PR TITLE
FIX Image Upload Preview Size

### DIFF
--- a/client/src/components/CreateNonFungiblePage/FileUpload.tsx
+++ b/client/src/components/CreateNonFungiblePage/FileUpload.tsx
@@ -11,7 +11,7 @@ import {
 export function FilePreview({ file }: { file: SelectedFile }) {
   const dispatch = useDispatch();
   if (/^image\/.*/.test(file.type)) {
-    return <Image src={file.objectUrl} />;
+    return <Image src={file.objectUrl} width="100%" height="100%" objectFit='contain' />;
   }
   if (/^video\/.*/.test(file.type)) {
     const canvasRef = createRef<HTMLCanvasElement>();
@@ -101,8 +101,16 @@ export default function FileUpload() {
       >
         <Box as="input" {...getInputProps()} />
         {state.selectedFile?.objectUrl ? (
-          <Box p={4} maxWidth="400px" maxHeight="400px">
-            <FilePreview file={state.selectedFile} />
+          <Box p={4}>
+            <Flex
+              justify="center"
+              align="center"
+              maxWidth="400px"
+              maxHeight="400px"
+              overflow="hidden"
+            >
+              <FilePreview file={state.selectedFile} />
+            </Flex>
           </Box>
         ) : (
           <Flex

--- a/client/src/components/CreateNonFungiblePage/Preview.tsx
+++ b/client/src/components/CreateNonFungiblePage/Preview.tsx
@@ -18,9 +18,9 @@ export default function Preview() {
       boxShadow="0px 0px 0px 4px rgba(211, 222, 245, 0.3)"
     >
       <Flex
-        width="100"
         justify="center"
         align="center"
+        width="300px"
         height="300px"
         overflow="hidden"
       >


### PR DESCRIPTION
This will fix the image preview upload size so that it is contained in the area

Note: This uses the original sizes of the containing box. But it fixes the preview card to always be 300x300 (since before it was using an invalid width "100" which was probably supposed to be "100%", but doesn't work well. The card makes more sense to have a square image area.

Also, though 'cover' might look better on the card, it could be confusing to the user why their image preview looks like it is cropped.

# Before:

![image](https://user-images.githubusercontent.com/703880/110224372-9f745300-7ea0-11eb-8aca-9489c27dc39e.png)


# After:

![image](https://user-images.githubusercontent.com/703880/110224364-8d92b000-7ea0-11eb-8e9f-e0f8b3209d14.png)
