### PR TITLE
Reskin of the asset detail page and Ntf metadata typing

### DIFF
--- a/docs/20200716_InitialOutline.md
+++ b/docs/20200716_InitialOutline.md
@@ -61,7 +61,7 @@ will be an element to also explore in future iterations.
      - Simple name
      - Description
      - Symbol
-     - General key-value pairs
+     - Attributes (General key-value pairs)
      - URL (IPFS image)
 - Contract with standard FA2 entry points
 - Backend 

--- a/scripts/bootstrap-contracts-config.ts
+++ b/scripts/bootstrap-contracts-config.ts
@@ -131,7 +131,8 @@ async function bootstrapContract(
   let contract;
   try {
     const { code, url: contractCodeUrl } = await fetchContractCode(
-      params.contractFilename, params.contractGitHash
+      params.contractFilename,
+      params.contractGitHash
     );
 
     $log.info(

--- a/src/components/Collections/TokenDetail/index.tsx
+++ b/src/components/Collections/TokenDetail/index.tsx
@@ -18,6 +18,7 @@ import {
   ModalCloseButton,
   ModalContent,
   ModalOverlay,
+  ResponsiveValue,
   Text,
   useDisclosure
 } from '@chakra-ui/react';
@@ -84,7 +85,13 @@ function MediaNotFound() {
   );
 }
 
-function TokenImage(props: { src: string }) {
+function TokenImage(props: {
+  src: string;
+  width?: string;
+  maxWidth?: string;
+  height?: string;
+  objectFit?: ResponsiveValue<any>;
+}) {
   const [errored, setErrored] = useState(false);
   const [obj, setObj] = useState<{ url: string; type: string } | null>(null);
   useEffect(() => {
@@ -112,8 +119,10 @@ function TokenImage(props: { src: string }) {
       <Image
         key={0}
         src={props.src}
-        objectFit="contain"
-        flex={1}
+        objectFit={props.objectFit}
+        width={props.width}
+        height={props.height}
+        maxWidth={props.maxWidth}
         onError={() => setErrored(true)}
       />
     );
@@ -176,10 +185,17 @@ function TokenDetail({ contractAddress, tokenId }: TokenDetailProps) {
         scrollBehavior="inside"
       >
         <ModalOverlay />
-        <ModalContent>
-          <ModalCloseButton />
+        <ModalContent
+          overflow="auto"
+          m="1rem"
+          maxHeight="calc(100vh - 2rem)"
+          display="unset"
+        >
+          <ModalCloseButton left="0.75rem" />
           <TokenImage
             src={ipfsUriToGatewayUrl(system.config.network, token.artifactUri)}
+            maxWidth="unset"
+            objectFit="none"
           />
         </ModalContent>
       </Modal>
@@ -204,10 +220,12 @@ function TokenDetail({ contractAddress, tokenId }: TokenDetailProps) {
         px={[4, 16]}
         mx="auto"
         width={['90%', '70%']}
+        maxHeight="70vh"
         flexDir="column"
       >
         <TokenImage
           src={ipfsUriToGatewayUrl(system.config.network, token.artifactUri)}
+          height="100%"
         />{' '}
         <Flex align="center" justify="space-evenly" width={['100%']} mt="4">
           {isOwner ? (

--- a/src/components/Collections/TokenDetail/index.tsx
+++ b/src/components/Collections/TokenDetail/index.tsx
@@ -345,7 +345,9 @@ function TokenDetail({ contractAddress, tokenId }: TokenDetailProps) {
                 disclosure={disclosure}
               />
             </Menu>
-          ) : null}
+          ) : (
+            <Flex w={[10]} />
+          )}
 
           {token.sale ? (
             isOwner ? (
@@ -370,7 +372,6 @@ function TokenDetail({ contractAddress, tokenId }: TokenDetailProps) {
                 width={['100%', 200]}
               >
                 <Flex align="center" justify="space-between" alignSelf="center">
-                  <Flex />
                   <Text color="black" fontSize="3xl" mr={1}>
                     ꜩ
                   </Text>

--- a/src/components/Collections/TokenDetail/index.tsx
+++ b/src/components/Collections/TokenDetail/index.tsx
@@ -39,7 +39,6 @@ import {
 } from '../../../reducer/async/queries';
 
 import { Maximize2 } from 'react-feather';
-import { random } from 'lodash';
 
 function NotFound() {
   return (
@@ -125,7 +124,7 @@ function TokenImage(props: {
     return (
       <Image
         id={props.id || 'assetImage'}
-        key={random()}
+        key={props.id || 'assetImage'}
         src={props.src}
         objectFit={props.objectFit}
         onError={() => setErrored(true)}
@@ -172,6 +171,22 @@ function TokenDetail({ contractAddress, tokenId }: TokenDetailProps) {
     }
   }, [contractAddress, tokenId, collectionUndefined, dispatch]);
 
+  useEffect(() => {
+    const img = document.getElementById('fullScreenAssetView');
+    if (img && zoom !== 0) {
+      console.log(
+        `${img.style.width}`,
+        `${imageWidth * zoom}`,
+        `${img.style.height}`,
+        `${imageHeight * zoom}`,
+        zoom
+      );
+      img.style.maxWidth = `${imageWidth}px`;
+      img.style.width = `${imageWidth * zoom}px`;
+      img.style.height = `${imageHeight * zoom}px`;
+    }
+  }, [imageHeight, imageWidth, zoom]);
+
   if (!collection?.tokens) {
     return null;
   }
@@ -185,8 +200,6 @@ function TokenDetail({ contractAddress, tokenId }: TokenDetailProps) {
     system.tzPublicKey &&
     (system.tzPublicKey === token.owner ||
       system.tzPublicKey === token.sale?.seller);
-
-  let img: HTMLImageElement;
 
   return (
     <Flex flexDir="column" bg="brand.brightGray">
@@ -203,10 +216,8 @@ function TokenDetail({ contractAddress, tokenId }: TokenDetailProps) {
           maxHeight="calc(100vh - 2rem)"
           display="unset"
           onLoad={e => {
-            e.preventDefault();
+            const img = document.getElementById('fullScreenAssetView');
             if (img) {
-              img.style.maxWidth = `${imageWidth}`;
-              img.style.maxHeight = `${imageHeight}`;
               if (imageHeight > e.currentTarget.scrollHeight) {
                 img.style.height = `calc(100% - 3rem)`;
                 img.style.margin = `auto`;
@@ -216,10 +227,14 @@ function TokenDetail({ contractAddress, tokenId }: TokenDetailProps) {
               }
               if (imageHeight > imageWidth) {
                 setZoom(e.currentTarget.scrollHeight / imageHeight);
-                img.style.width = `${zoom * imageWidth}`;
+                img.style.width = `${
+                  (e.currentTarget.scrollHeight / imageHeight) * imageWidth
+                }px`;
               } else {
                 setZoom(e.currentTarget.scrollWidth / imageWidth);
-                img.style.height = `${zoom * imageHeight}`;
+                img.style.height = `${
+                  (e.currentTarget.scrollWidth / imageWidth) * imageHeight
+                }px`;
               }
             }
           }}
@@ -228,12 +243,12 @@ function TokenDetail({ contractAddress, tokenId }: TokenDetailProps) {
             <ModalCloseButton position="relative" right={0} top={0} />
             <Slider
               defaultValue={zoom}
-              min={zoom}
+              min={0}
               max={1}
               step={0.01}
               width="10rem"
               margin="auto"
-              onChange={console.log}
+              onChange={setZoom}
             >
               <SliderTrack>
                 <SliderFilledTrack />
@@ -246,10 +261,8 @@ function TokenDetail({ contractAddress, tokenId }: TokenDetailProps) {
             id="fullScreenAssetView"
             src={ipfsUriToGatewayUrl(system.config.network, token.artifactUri)}
             onLoad={e => {
-              e.preventDefault();
               setImageHeight(e.currentTarget.height);
               setImageWidth(e.currentTarget.width);
-              img = e.currentTarget;
             }}
           />
         </ModalContent>

--- a/src/components/Collections/TokenDetail/index.tsx
+++ b/src/components/Collections/TokenDetail/index.tsx
@@ -262,10 +262,10 @@ function TokenDetail({ contractAddress, tokenId }: TokenDetailProps) {
                 <BuyTokenButton contract={contractAddress} token={token} />
               </Flex>
             )
+          ) : isOwner ? (
+            <SellTokenButton contract={contractAddress} tokenId={tokenId} />
           ) : (
-            <>
-              <SellTokenButton contract={contractAddress} tokenId={tokenId} />
-            </>
+            <></>
           )}
           <Button onClick={onOpen}>
             <Maximize2 size={16} strokeWidth="3" />

--- a/src/components/CreateNonFungiblePage/Form.tsx
+++ b/src/components/CreateNonFungiblePage/Form.tsx
@@ -68,7 +68,7 @@ export default function Form() {
       <Heading size="md" paddingBottom={6}>
         Add attributes to your asset
       </Heading>
-      {state.metadataRows.map(({ name, value }, key) => {
+      {state.attributes.map(({ name, value }, key) => {
         return (
           <Flex key={key} align="center" justify="stretch">
             <FormControl paddingBottom={6} paddingRight={2} flex="1">

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,25 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+::-webkit-scrollbar-track {
+  border-radius: 4px;
+  background-color: #DADADA;
+}
+
+::-webkit-scrollbar-thumb {
+  border-radius: 4px;
+  background-color: #888;
+}
+::-webkit-scrollbar {
+  height: 8px;
+  width: 8px;
+  background-color: #DADADA;
+}
+
+.bg-dropdown-arrow {
+  background-origin: content-box;
+}
+
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -184,7 +184,8 @@ const theme = extendTheme({
     brand: {
       black: '#1D2227',
       background: '#1C2228',
-      darkGray: '#3B4650',
+      darkGray: '#3D464F',
+      neutralGray: '#556677',
       gray: '#AEBBC9',
       lightGray: '#ABBBCB',
       brightGray: '#F2F4F7',

--- a/src/lib/nfts/actions.ts
+++ b/src/lib/nfts/actions.ts
@@ -4,6 +4,7 @@ import { SystemWithWallet } from '../system';
 import faucetCode from './code/fa2_tzip16_compat_multi_nft_faucet';
 import assetCode from './code/fa2_tzip16_compat_multi_nft_asset';
 import { uploadIPFSJSON } from '../util/ipfs';
+import { NftMetadata } from './queries';
 
 function toHexString(input: string) {
   return Buffer.from(input).toString('hex');
@@ -73,7 +74,7 @@ export async function createAssetContract(
 export async function mintToken(
   system: SystemWithWallet,
   address: string,
-  metadata: Record<string, string>
+  metadata: NftMetadata
 ) {
   const contract = await system.toolkit.wallet.at(address);
   const storage = await contract.storage<any>();

--- a/src/lib/nfts/queries.ts
+++ b/src/lib/nfts/queries.ts
@@ -26,7 +26,7 @@ export interface Nft {
   owner: string;
   description: string;
   artifactUri: string;
-  metadata: Record<string, string>;
+  metadata: NftMetadata;
   sale?: NftSale;
   address?: string;
 }
@@ -77,6 +77,61 @@ export async function getMarketplaceNfts(
       }
     )
   );
+}
+
+export interface NftMetadata {
+  ""?: string;
+  name?: string;
+  symbol?: string;
+  decimals?: number;
+  rightUri?: string;
+  artifactUri?: string;
+  displayUri?: string;
+  thumbnailUri?: string;
+  externalUri?: string;
+  description?: string;
+  creators?: Array<string>;
+  contributors?: Array<string>;
+  publishers?: Array<string>;
+  date?: string;
+  blocklevel?: number;
+  type?: string;
+  tags?: Array<string>;
+  genres?: Array<string>;
+  language?: string;
+  identifier?: string;
+  rights?: string;
+  isTransferable?: boolean;
+  isBooleanAmount?: boolean;
+  shouldPreferSymbol?: boolean;
+  formats?: Array<NftMetadataFormat>;
+  attributes?: Array<NftMetadataAttribute>;
+}
+
+export interface NftMetadataFormat {
+  uri: string;
+  hash: string;
+  mimeType: string;
+  fileSize: number;
+  fileName: string;
+  duration: string;
+  dimensions: NtfMetadataFormatDimensions;
+  dataRate: NtfMetadataFormatDataRate;
+}
+
+export interface NtfMetadataFormatDataRate {
+  value: number;
+  unit: string;
+}
+export interface NtfMetadataFormatDimensions {
+  value: string;
+  unit: string;
+}
+
+export interface NftMetadataAttribute {
+  name: string | null;
+  value: string | null;
+  type?: string;
 }
 
 export async function getContractNfts(
@@ -156,7 +211,7 @@ export async function getContractNfts(
           description: metadata.description,
           artifactUri: metadata.artifactUri,
           metadata: metadata,
-          sale: sale
+          sale,
         };
       }
     )

--- a/src/lib/nfts/queries.ts
+++ b/src/lib/nfts/queries.ts
@@ -79,7 +79,13 @@ export async function getMarketplaceNfts(
   );
 }
 
-export interface NftMetadata {
+export class NftMetadata {
+  [index: string]:
+    | string
+    | undefined
+    | number
+    | Array<String | NftMetadataFormat | NftMetadataAttribute>
+    | boolean;
   ''?: string;
   name?: string;
   minter?: string;
@@ -107,6 +113,64 @@ export interface NftMetadata {
   shouldPreferSymbol?: boolean;
   formats?: Array<NftMetadataFormat>;
   attributes?: Array<NftMetadataAttribute>;
+
+  constructor(
+    root?: string,
+    name?: string,
+    minter?: string,
+    symbol?: string,
+    decimals?: number,
+    rightUri?: string,
+    artifactUri?: string,
+    displayUri?: string,
+    thumbnailUri?: string,
+    externalUri?: string,
+    description?: string,
+    creators?: Array<string>,
+    contributors?: Array<string>,
+    publishers?: Array<string>,
+    date?: string,
+    blocklevel?: number,
+    type?: string,
+    tags?: Array<string>,
+    genres?: Array<string>,
+    language?: string,
+    identifier?: string,
+    rights?: string,
+    isTransferable?: boolean,
+    isBooleanAmount?: boolean,
+    shouldPreferSymbol?: boolean,
+    formats?: Array<NftMetadataFormat>,
+    attributes?: Array<NftMetadataAttribute>
+  ) {
+    this[''] = root;
+    this.name = name;
+    this.minter = minter;
+    this.symbol = symbol;
+    this.decimals = decimals;
+    this.rightUri = rightUri;
+    this.artifactUri = artifactUri;
+    this.displayUri = displayUri;
+    this.thumbnailUri = thumbnailUri;
+    this.externalUri = externalUri;
+    this.description = description;
+    this.creators = creators;
+    this.contributors = contributors;
+    this.publishers = publishers;
+    this.date = date;
+    this.blocklevel = blocklevel;
+    this.type = type;
+    this.tags = tags;
+    this.genres = genres;
+    this.language = language;
+    this.identifier = identifier;
+    this.rights = rights;
+    this.isTransferable = isTransferable;
+    this.isBooleanAmount = isBooleanAmount;
+    this.shouldPreferSymbol = shouldPreferSymbol;
+    this.formats = formats;
+    this.attributes = attributes;
+  }
 }
 
 export interface NftMetadataFormat {

--- a/src/lib/nfts/queries.ts
+++ b/src/lib/nfts/queries.ts
@@ -80,8 +80,9 @@ export async function getMarketplaceNfts(
 }
 
 export interface NftMetadata {
-  ""?: string;
+  ''?: string;
   name?: string;
+  minter?: string;
   symbol?: string;
   decimals?: number;
   rightUri?: string;
@@ -163,11 +164,15 @@ export async function getContractNfts(
   if (!tokens) return [];
 
   // get tokens listed for sale
-  const fixedPriceStorage = await system.betterCallDev.getContractStorage(system.config.contracts.marketplace.fixedPrice.tez);
+  const fixedPriceStorage = await system.betterCallDev.getContractStorage(
+    system.config.contracts.marketplace.fixedPrice.tez
+  );
   const fixedPriceBigMapId = select(fixedPriceStorage, {
     type: 'big_map'
   })?.value;
-  const fixedPriceSales = await system.betterCallDev.getBigMapKeys(fixedPriceBigMapId);
+  const fixedPriceSales = await system.betterCallDev.getBigMapKeys(
+    fixedPriceBigMapId
+  );
 
   return Promise.all(
     tokens.map(
@@ -190,8 +195,10 @@ export async function getContractNfts(
         const owner = select(entry, { type: 'address' })?.value;
 
         const saleData = fixedPriceSales.filter((v: any) => {
-          return select(v, { name: 'token_for_sale_address' })?.value === address &&
+          return (
+            select(v, { name: 'token_for_sale_address' })?.value === address &&
             select(v, { name: 'token_for_sale_token_id' })?.value === tokenId
+          );
         });
 
         let sale = undefined;
@@ -211,7 +218,7 @@ export async function getContractNfts(
           description: metadata.description,
           artifactUri: metadata.artifactUri,
           metadata: metadata,
-          sale,
+          sale
         };
       }
     )
@@ -254,13 +261,14 @@ export async function getWalletNftAssetContracts(system: SystemWithWallet) {
   const bcd = system.betterCallDev;
   const response = await bcd.getWalletContracts(system.tzPublicKey);
   const assetContracts = response.items.filter(
-    (i: any) => Object.keys(i.body).includes("tags") &&
-                i.body.tags.includes("fa2") &&
-                Object.keys(i.body).includes("entrypoints") &&
-                i.body.entrypoints.includes("balance_of") &&
-                i.body.entrypoints.includes("mint") &&
-                i.body.entrypoints.includes("transfer") &&
-                i.body.entrypoints.includes("update_operators")
+    (i: any) =>
+      Object.keys(i.body).includes('tags') &&
+      i.body.tags.includes('fa2') &&
+      Object.keys(i.body).includes('entrypoints') &&
+      i.body.entrypoints.includes('balance_of') &&
+      i.body.entrypoints.includes('mint') &&
+      i.body.entrypoints.includes('transfer') &&
+      i.body.entrypoints.includes('update_operators')
   );
 
   const results = [];

--- a/src/reducer/async/actions.ts
+++ b/src/reducer/async/actions.ts
@@ -101,8 +101,13 @@ function appendStateMetadata(
 
   for (let row of state.attributes) {
     if (row.name !== null && row.value !== null) {
-      if (!appendedMetadata.attributes) appendedMetadata.attributes = [];
-      appendedMetadata.attributes.push({ name: row.name, value: row.value });
+      const keys = Object.getOwnPropertyNames(new NftMetadata());
+      if (keys.indexOf(row.name) !== -1) {
+        appendedMetadata[row.name as keyof NftMetadata] = row.value;
+      } else {
+        if (!appendedMetadata.attributes) appendedMetadata.attributes = [];
+        appendedMetadata.attributes.push({ name: row.name, value: row.value });
+      }
     }
   }
 

--- a/src/reducer/async/actions.ts
+++ b/src/reducer/async/actions.ts
@@ -90,7 +90,7 @@ export const createAssetContractAction = createAsyncThunk<
 function appendStateMetadata(
   state: State['createNft'],
   metadata: NftMetadata,
-  system: SystemWithToolkit | SystemWithWallet,
+  system: SystemWithToolkit | SystemWithWallet
 ) {
   const appendedMetadata = { ...metadata };
   appendedMetadata.name = state.fields.name as string;
@@ -101,13 +101,12 @@ function appendStateMetadata(
 
   for (let row of state.attributes) {
     if (row.name !== null && row.value !== null) {
-      if(!appendedMetadata.attributes) appendedMetadata.attributes = []
-      appendedMetadata.attributes.push({name: row.name, value: row.value});
+      if (!appendedMetadata.attributes) appendedMetadata.attributes = [];
+      appendedMetadata.attributes.push({ name: row.name, value: row.value });
     }
   }
 
-  if (!appendedMetadata.creators) appendedMetadata.creators = []
-  appendedMetadata.creators.push(system.tzPublicKey || "")
+  appendedMetadata.minter = system.tzPublicKey || '';
 
   return appendedMetadata;
 }

--- a/src/reducer/slices/createNft.ts
+++ b/src/reducer/slices/createNft.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { NftMetadataAttribute } from '../../lib/nfts/queries';
 import { readFileAsDataUrlAction } from '../async/actions';
 
 // State
@@ -40,7 +41,7 @@ export interface CreateNftState {
   displayImageFile: SelectedFile | null;
   uploadedArtifact: UploadedArtifact | null;
   fields: Fields;
-  metadataRows: { name: string | null; value: string | null }[];
+  attributes: Array<NftMetadataAttribute>;
   collectionAddress: string | null;
   createStatus: CreateStatus;
 }
@@ -54,7 +55,7 @@ export const initialState: CreateNftState = {
     name: null,
     description: null
   },
-  metadataRows: [],
+  attributes: [],
   collectionAddress: null,
   createStatus: CreateStatus.Ready
 };
@@ -99,20 +100,20 @@ const slice = createSlice({
       state.displayImageFile = null;
     },
     addMetadataRow(state) {
-      state.metadataRows.push({ name: null, value: null });
+      state.attributes.push({ name: null, value: null });
     },
     updateMetadataRowName(state, action: UpdateRowNameAction) {
-      if (state.metadataRows[action.payload.key]) {
-        state.metadataRows[action.payload.key].name = action.payload.name;
+      if (state.attributes[action.payload.key]) {
+        state.attributes[action.payload.key].name = action.payload.name;
       }
     },
     updateMetadataRowValue(state, action: UpdateRowValueAction) {
-      if (state.metadataRows[action.payload.key]) {
-        state.metadataRows[action.payload.key].value = action.payload.value;
+      if (state.attributes[action.payload.key]) {
+        state.attributes[action.payload.key].value = action.payload.value;
       }
     },
     deleteMetadataRow(state, action: PayloadAction<{ key: number }>) {
-      state.metadataRows.splice(action.payload.key, 1);
+      state.attributes.splice(action.payload.key, 1);
     },
     selectCollection(state, action: PayloadAction<string>) {
       state.collectionAddress = action.payload;


### PR DESCRIPTION
This adds a new UI to the asset details page, as per the Figma sketches, and also adds the [specified](https://gitlab.com/tzip/tzip/-/blob/master/proposals/tzip-21/tzip-21.md) types to the `metadata` object.