### PR TITLE
Adds pagination to collection assets listing and collection

### DIFF
--- a/src/components/Collections/TokenDetail/index.tsx
+++ b/src/components/Collections/TokenDetail/index.tsx
@@ -22,6 +22,7 @@ import {
   getContractNftsQuery,
   getNftAssetContractQuery
 } from '../../../reducer/async/queries';
+import { AssetContract } from '../../../lib/nfts/queries';
 
 function NotFound() {
   return (
@@ -135,9 +136,20 @@ function TokenDetail({ contractAddress, tokenId }: TokenDetailProps) {
     if (collectionUndefined) {
       dispatch(getNftAssetContractQuery(contractAddress));
     } else {
-      dispatch(getContractNftsQuery(contractAddress));
+      dispatch(
+        getContractNftsQuery({
+          collection: state.collections[contractAddress],
+          purge: false
+        })
+      );
     }
-  }, [contractAddress, tokenId, collectionUndefined, dispatch]);
+  }, [
+    contractAddress,
+    tokenId,
+    collectionUndefined,
+    state.collections,
+    dispatch
+  ]);
 
   if (!collection?.tokens) {
     return null;
@@ -229,7 +241,7 @@ function TokenDetail({ contractAddress, tokenId }: TokenDetailProps) {
                   </MenuList>
                 </Menu>
                 <TransferTokenModal
-                  contractAddress={contractAddress}
+                  contract={state.collections[contractAddress]}
                   tokenId={tokenId}
                   disclosure={disclosure}
                 />
@@ -354,18 +366,25 @@ function TokenDetail({ contractAddress, tokenId }: TokenDetailProps) {
                 <Box>
                   {token.sale ? (
                     <CancelTokenSaleButton
-                      contract={contractAddress}
+                      contract={
+                        state.collections[contractAddress] as AssetContract
+                      }
                       tokenId={tokenId}
                     />
                   ) : (
                     <SellTokenButton
-                      contract={contractAddress}
+                      contract={
+                        state.collections[contractAddress] as AssetContract
+                      }
                       tokenId={tokenId}
                     />
                   )}
                 </Box>
               ) : token.sale ? (
-                <BuyTokenButton contract={contractAddress} token={token} />
+                <BuyTokenButton
+                  contract={state.collections[contractAddress] as AssetContract}
+                  token={token}
+                />
               ) : null}
             </Flex>
           </Box>

--- a/src/components/CreateNonFungiblePage/index.tsx
+++ b/src/components/CreateNonFungiblePage/index.tsx
@@ -67,6 +67,7 @@ export default function CreateNonFungiblePage() {
   const dispatch = useDispatch();
   const [, setLocation] = useLocation();
   const { isOpen, onClose, onOpen } = useDisclosure();
+  const { collections } = useSelector(s => s);
   useEffect(() => {
     if (system.status !== 'WalletConnected') {
       setLocation('/');
@@ -137,7 +138,7 @@ export default function CreateNonFungiblePage() {
                   }
                   case 'collection_select': {
                     onOpen();
-                    return dispatch(mintTokenAction());
+                    return dispatch(mintTokenAction({ collections }));
                   }
                 }
               }}
@@ -155,7 +156,7 @@ export default function CreateNonFungiblePage() {
               }}
               onRetry={() => {
                 dispatch(clearError({ method: 'mintToken' }));
-                dispatch(mintTokenAction());
+                dispatch(mintTokenAction({ collections }));
               }}
               onCancel={() => {
                 onClose();

--- a/src/components/common/BuyToken.tsx
+++ b/src/components/common/BuyToken.tsx
@@ -20,10 +20,10 @@ import { MinterButton } from '../common';
 import { useSelector, useDispatch } from '../../reducer';
 import { buyTokenAction } from '../../reducer/async/actions';
 import { setStatus } from '../../reducer/slices/status';
-import { Nft } from '../../lib/nfts/queries';
+import { AssetContract, Nft } from '../../lib/nfts/queries';
 
 interface BuyTokenButtonProps {
-  contract: string;
+  contract: AssetContract;
   token: Nft;
 }
 
@@ -39,7 +39,7 @@ export function BuyTokenButton(props: BuyTokenButtonProps) {
       buyTokenAction({
         contract: props.contract,
         tokenId: props.token.id,
-        tokenSeller: props.token.sale?.seller || "",
+        tokenSeller: props.token.sale?.seller || '',
         salePrice: props.token.sale?.price || 0
       })
     );
@@ -54,7 +54,9 @@ export function BuyTokenButton(props: BuyTokenButtonProps) {
 
   return (
     <>
-      <MinterButton variant="primaryAction" onClick={onOpen}>Buy now</MinterButton>
+      <MinterButton variant="primaryAction" onClick={onOpen}>
+        Buy now
+      </MinterButton>
 
       <Modal
         isOpen={isOpen}
@@ -70,18 +72,26 @@ export function BuyTokenButton(props: BuyTokenButtonProps) {
         <ModalContent mt={40}>
           {status === 'ready' ? (
             <>
-            <ModalHeader>Checkout</ModalHeader>
-            <ModalCloseButton />
-            <ModalBody>
-              <Text>
-                You are about to purchase<Box as="span" fontWeight="bold"> {props.token.title} (ꜩ {props.token.sale?.price})</Box>
-              </Text>
-            </ModalBody>
-            <ModalFooter>
-              <Button variant="primaryAction" onClick={onSubmit} isFullWidth={true}>
-                Buy now
-              </Button>
-            </ModalFooter>
+              <ModalHeader>Checkout</ModalHeader>
+              <ModalCloseButton />
+              <ModalBody>
+                <Text>
+                  You are about to purchase
+                  <Box as="span" fontWeight="bold">
+                    {' '}
+                    {props.token.title} (ꜩ {props.token.sale?.price})
+                  </Box>
+                </Text>
+              </ModalBody>
+              <ModalFooter>
+                <Button
+                  variant="primaryAction"
+                  onClick={onSubmit}
+                  isFullWidth={true}
+                >
+                  Buy now
+                </Button>
+              </ModalFooter>
             </>
           ) : null}
           {status === 'in_transit' ? (

--- a/src/components/common/SellToken.tsx
+++ b/src/components/common/SellToken.tsx
@@ -22,8 +22,12 @@ import {
 import { Check, CheckCircle } from 'react-feather';
 import { MinterButton } from '../common';
 import { useSelector, useDispatch } from '../../reducer';
-import { listTokenAction, cancelTokenSaleAction } from '../../reducer/async/actions';
+import {
+  listTokenAction,
+  cancelTokenSaleAction
+} from '../../reducer/async/actions';
 import { setStatus } from '../../reducer/slices/status';
+import { AssetContract } from '../../lib/nfts/queries';
 
 interface FormProps {
   initialRef: MutableRefObject<null>;
@@ -31,7 +35,7 @@ interface FormProps {
 }
 
 interface SellTokenButtonProps {
-  contract: string;
+  contract: AssetContract;
   tokenId: number;
 }
 
@@ -43,31 +47,31 @@ function FormFixedPrice({ initialRef, onSubmit }: FormProps) {
       <ModalCloseButton />
       <ModalBody>
         <Flex>
-        <FormControl>
-          <InputGroup>
-            <InputLeftElement
-              pointerEvents="none"
-              color="gray.900"
-              fontSize="1.2em"
-              children="ꜩ"
-            />
-            <Input
-              autoFocus={true}
-              ref={initialRef}
-              placeholder="Enter sale amount"
-              value={salePrice}
-              onChange={e => setSalePrice(e.target.value)}
-            />
-          </InputGroup>
-        </FormControl>
-        <Box ml={2}>
-        <MinterButton
-          variant="primaryAction"
-          onClick={() => onSubmit({ salePrice })}
-        >
-          <Check />
-        </MinterButton>
-        </Box>
+          <FormControl>
+            <InputGroup>
+              <InputLeftElement
+                pointerEvents="none"
+                color="gray.900"
+                fontSize="1.2em"
+                children="ꜩ"
+              />
+              <Input
+                autoFocus={true}
+                ref={initialRef}
+                placeholder="Enter sale amount"
+                value={salePrice}
+                onChange={e => setSalePrice(e.target.value)}
+              />
+            </InputGroup>
+          </FormControl>
+          <Box ml={2}>
+            <MinterButton
+              variant="primaryAction"
+              onClick={() => onSubmit({ salePrice })}
+            >
+              <Check />
+            </MinterButton>
+          </Box>
         </Flex>
       </ModalBody>
       <ModalFooter />
@@ -104,7 +108,9 @@ export function SellTokenButton(props: SellTokenButtonProps) {
 
   return (
     <>
-      <MinterButton variant="primaryAction" onClick={onOpen}>List for sale</MinterButton>
+      <MinterButton variant="primaryAction" onClick={onOpen}>
+        List for sale
+      </MinterButton>
 
       <Modal
         isOpen={isOpen}
@@ -171,7 +177,9 @@ export function CancelTokenSaleButton(props: SellTokenButtonProps) {
 
   return (
     <>
-      <MinterButton variant="cancelAction" onClick={onOpen}>Cancel sale</MinterButton>
+      <MinterButton variant="cancelAction" onClick={onOpen}>
+        Cancel sale
+      </MinterButton>
 
       <Modal
         isOpen={isOpen}
@@ -186,17 +194,19 @@ export function CancelTokenSaleButton(props: SellTokenButtonProps) {
         <ModalContent mt={40}>
           {status === 'ready' ? (
             <>
-            <ModalHeader>Are you sure?</ModalHeader>
-            <ModalCloseButton />
-            <ModalBody>
-              <Text>
-                Are you sure you want to cancel the sale?
-              </Text>
-            </ModalBody>
-            <ModalFooter>
-              <Button variant="primaryAction" mr={3} onClick={onSubmit}>Yes</Button>
-              <Button variant="cancelAction" onClick={onClose}>No</Button>
-            </ModalFooter>
+              <ModalHeader>Are you sure?</ModalHeader>
+              <ModalCloseButton />
+              <ModalBody>
+                <Text>Are you sure you want to cancel the sale?</Text>
+              </ModalBody>
+              <ModalFooter>
+                <Button variant="primaryAction" mr={3} onClick={onSubmit}>
+                  Yes
+                </Button>
+                <Button variant="cancelAction" onClick={onClose}>
+                  No
+                </Button>
+              </ModalFooter>
             </>
           ) : null}
           {status === 'in_transit' ? (

--- a/src/components/common/TransferToken.tsx
+++ b/src/components/common/TransferToken.tsx
@@ -28,6 +28,7 @@ import { MinterButton } from '../common';
 import { useSelector, useDispatch } from '../../reducer';
 import { transferTokenAction } from '../../reducer/async/actions';
 import { clearError, setStatus, Status } from '../../reducer/slices/status';
+import { Collection } from '../../reducer/slices/collections';
 
 interface FormProps {
   initialRef: MutableRefObject<null>;
@@ -135,7 +136,7 @@ function Content({ status, onClose, onRetry, onCancel }: ContentProps) {
 }
 
 interface TransferTokenModalProps {
-  contractAddress: string;
+  contract: Collection;
   tokenId: number;
   disclosure: UseDisclosureReturn;
 }
@@ -151,7 +152,7 @@ export function TransferTokenModal(props: TransferTokenModalProps) {
   const onSubmit = async () => {
     dispatch(
       transferTokenAction({
-        contract: props.contractAddress,
+        contract: props.contract,
         tokenId: props.tokenId,
         to: toAddress
       })
@@ -206,7 +207,7 @@ export function TransferTokenModal(props: TransferTokenModalProps) {
 }
 
 interface TransferTokenButtonProps {
-  contractAddress: string;
+  contract: Collection;
   tokenId: number;
 }
 

--- a/src/lib/service/bcd.ts
+++ b/src/lib/service/bcd.ts
@@ -1,9 +1,17 @@
 import axios from 'axios';
 import { Config } from '../system';
 
-export async function getBigMapKeys(config: Config, id: number) {
+export async function getBigMapKeys(
+  config: Config,
+  id: number,
+  offset: number
+) {
   const uri = `${config.bcd.api}/v1/bigmap/${config.network}/${id}/keys`;
-  const response = await axios.get(uri);
+  const response = await axios.get(uri, {
+    params: {
+      offset
+    }
+  });
   return response.data;
 }
 
@@ -30,9 +38,17 @@ export async function getContractOperations(
   return response.data;
 }
 
-export async function getWalletContracts(config: Config, address: string) {
+export async function getWalletContracts(
+  config: Config,
+  address: string,
+  offset: number
+) {
   const uri = `${config.bcd.api}/v1/search?q=${address}&i=contract&n=${config.network}&g=0&s=0`;
-  const response = await axios.get(uri);
+  const response = await axios.get(uri, {
+    params: {
+      o: offset
+    }
+  });
   return response.data;
 }
 
@@ -49,8 +65,8 @@ export class BetterCallDev {
     this.config = config;
   }
 
-  getBigMapKeys(id: number) {
-    return getBigMapKeys(this.config, id);
+  getBigMapKeys(id: number, offset: number = 0) {
+    return getBigMapKeys(this.config, id, offset);
   }
 
   getContract(address: string) {
@@ -65,8 +81,8 @@ export class BetterCallDev {
     return getContractOperations(this.config, address, since);
   }
 
-  getWalletContracts(address: string) {
-    return getWalletContracts(this.config, address);
+  getWalletContracts(address: string, offset: number = 0) {
+    return getWalletContracts(this.config, address, offset);
   }
 
   getAccountMetadata(address: string) {

--- a/src/reducer/async/queries.ts
+++ b/src/reducer/async/queries.ts
@@ -8,6 +8,7 @@ import {
   getWalletNftAssetContracts
 } from '../../lib/nfts/queries';
 import { ErrorKind, RejectValue } from './errors';
+import { Collection } from '../slices/collections';
 
 type Opts = { state: State; rejectValue: RejectValue };
 
@@ -29,21 +30,24 @@ export const getNftAssetContractQuery = createAsyncThunk<
 });
 
 export const getContractNftsQuery = createAsyncThunk<
-  { address: string; tokens: Nft[] },
-  string,
+  { collection: Collection | AssetContract; tokens: Nft[] },
+  { collection: Collection | AssetContract; purge: boolean },
   Opts
->('query/getContractNfts', async (address, { getState, rejectWithValue }) => {
-  const { system } = getState();
-  try {
-    const tokens = await getContractNfts(system, address);
-    return { address, tokens };
-  } catch (e) {
-    return rejectWithValue({
-      kind: ErrorKind.GetContractNftsFailed,
-      message: `Failed to retrieve contract nfts from: ${address}`
-    });
+>(
+  'query/getContractNfts',
+  async ({ collection, purge }, { getState, rejectWithValue }) => {
+    const { system } = getState();
+    try {
+      const tokens = await getContractNfts(system, collection, purge);
+      return { collection, tokens };
+    } catch (e) {
+      return rejectWithValue({
+        kind: ErrorKind.GetContractNftsFailed,
+        message: `Failed to retrieve contract nfts from: ${collection}`
+      });
+    }
   }
-});
+);
 
 export const getWalletAssetContractsQuery = createAsyncThunk<
   AssetContract[],

--- a/src/reducer/slices/collections.ts
+++ b/src/reducer/slices/collections.ts
@@ -38,18 +38,23 @@ export const initialState: CollectionsState = {
       metadata: {
         name: 'Minter'
       },
-      tokens: null
+      tokens: null,
+      ledgerId: 29150,
+      tokensId: 29152
     }
   }
 };
 
 //// Reducers & Slice
 
-type PopulateCollection = Reducer<{ address: string; tokens: Token[] }>;
+type PopulateCollection = Reducer<{
+  collection: AssetContract;
+  tokens: Token[];
+}>;
 
 const populateCollectionR: PopulateCollection = (state, { payload }) => {
-  if (state.collections[payload.address]) {
-    state.collections[payload.address].tokens = payload.tokens;
+  if (state.collections[payload.collection.address]) {
+    state.collections[payload.collection.address].tokens = payload.tokens;
   }
 };
 


### PR DESCRIPTION
This uses the offset properties of the BCD API to paginate the collection listing. Also fetches all the available collections on load, removing the current limit of 10 collection, as well 10 assets of a collection.
#239 is also fixed with this changes