### PR TITLE
Cleanup: Marketplace card info & logo 

### DIFF
--- a/src/components/Marketplace/Catalog/FeaturedToken.tsx
+++ b/src/components/Marketplace/Catalog/FeaturedToken.tsx
@@ -34,11 +34,11 @@ export default function FeaturedToken(props: FeaturedTokenProps) {
             <Heading size="md" mt={4} fontSize="2.5rem">
               {props.title}
             </Heading>
-            <br/>
             <Text fontSize="sm" fontWeight="600" color="gray.500">
               {props.description}
             </Text>
             <Spacer />
+            <br />
             <Text fontSize="md">
               Current Price:{' '}
               <Text as="span" fontWeight="600">

--- a/src/components/Marketplace/Catalog/FeaturedToken.tsx
+++ b/src/components/Marketplace/Catalog/FeaturedToken.tsx
@@ -34,12 +34,7 @@ export default function FeaturedToken(props: FeaturedTokenProps) {
             <Heading size="md" mt={4} fontSize="2.5rem">
               {props.title}
             </Heading>
-            <Heading size="sm" my={4} color="brand.darkGray">
-              {props.title}
-            </Heading>
-            <Heading size="sm" my={4} color="brand.darkGray">
-              Seller: {props.sale?.seller}
-            </Heading>
+            <br/>
             <Text fontSize="sm" fontWeight="600" color="gray.500">
               {props.description}
             </Text>

--- a/src/components/Marketplace/Catalog/TokenCard.tsx
+++ b/src/components/Marketplace/Catalog/TokenCard.tsx
@@ -48,7 +48,6 @@ export default function TokenCard(props: TokenCardProps) {
         flexDir="column"
       >
         <Heading size="sm">{props.title}</Heading>
-        <Text fontSize="sm">Seller: {props.sale?.seller.substr(0, 5)}...{props.sale?.seller.substr(-5)}</Text>
       </Flex>
       <Flex
         px={2}

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -317,7 +317,7 @@ export function Header() {
         src={logo}
         onClick={e => {
           e.preventDefault();
-          setLocation('/collections');
+          setLocation('/marketplace');
         }}
         cursor="pointer"
       />
@@ -330,7 +330,7 @@ export function Header() {
         src={headerLogo}
         onClick={e => {
           e.preventDefault();
-          setLocation('/collections');
+          setLocation('/marketplace');
         }}
         cursor="pointer"
       />


### PR DESCRIPTION
- Removed seller from spotlight & cards 
- Removed duplication of asset title in spotlight card
- Bugfix: logo doesn't redirect to discontinued splash page when disconnected